### PR TITLE
feat: add token account relationship

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -23,6 +23,8 @@ type Account @entity {
   id: ID!
   titleEscrowsAsBeneficiary: [TitleEscrow!]! @derivedFrom(field: "beneficiary")
   titleEscrowsAsHolder: [TitleEscrow!]! @derivedFrom(field: "holder")
+  tokensAsBeneficiary: [Token!]! @derivedFrom(field: "beneficiary")
+  tokensAsHolder: [Token!]! @derivedFrom(field: "holder")
   tokenTransfersAsFromBeneficiary: [TokenTransfer!]! @derivedFrom(field: "fromBeneficiary")
   tokenTransfersAsFromHolder: [TokenTransfer!]! @derivedFrom(field: "fromHolder")
   tokenTransfersAsToBeneficiary: [TokenTransfer!]! @derivedFrom(field: "toBeneficiary")
@@ -110,6 +112,8 @@ type Token @entity {
   documentIdHex: String!
   registry: TokenRegistry!
   titleEscrow: TitleEscrow
+  beneficiary: Account
+  holder: Account
   surrendered: Boolean!
   transferEvents: [TokenTransfer!]! @derivedFrom(field: "token")
   titleEscrowHolderTransferEvents: [TitleEscrowHolderTransfer!]! @derivedFrom(field: "token")

--- a/src/escrow.ts
+++ b/src/escrow.ts
@@ -60,6 +60,8 @@ export function handleTitleCeded(event: TitleCededEvent): void {
 }
 
 export function handleHolderChanged(event: HolderChangedEvent): void {
+  if (event.params.previousHolder.equals(Address.zero())) return;
+
   const titleEscrowEntity = fetchTitleEscrow(event.address);
 
   const tokenEntity = Token.load(titleEscrowEntity.token);
@@ -69,9 +71,7 @@ export function handleHolderChanged(event: HolderChangedEvent): void {
   }
 
   const entityId = `${event.address.toHex()}-${event.logIndex.toString()}`;
-  const prevHolder = event.params.previousHolder.equals(Address.zero())
-    ? ""
-    : event.params.previousHolder.toHex();
+  const prevHolder = event.params.previousHolder.toHex();
 
   const titleEscrowHolderTransferEntity = new TitleEscrowHolderTransfer(entityId);
   titleEscrowHolderTransferEntity.transaction = fetchTransaction(event).id;

--- a/src/escrow.ts
+++ b/src/escrow.ts
@@ -3,7 +3,7 @@ import {
   HolderChanged as HolderChangedEvent, Surrender as SurrenderEvent, TitleCeded as TitleCededEvent,
   TitleEscrowCloneable, TransferTitleEscrowApproval as TransferTitleEscrowApprovalEvent,
 } from "../generated/templates/TitleEscrowCloneable/TitleEscrowCloneable";
-import { Surrender, TitleEscrowApproval, TitleEscrowHolderTransfer } from "../generated/schema";
+import { Surrender, TitleEscrowApproval, TitleEscrowHolderTransfer, Token } from "../generated/schema";
 import { fetchAccount, fetchTitleEscrow, fetchToken, fetchTokenRegistry, fetchTransaction } from "./utils/fetchers";
 import { getTokenEntityId } from "./utils/helpers";
 
@@ -60,14 +60,15 @@ export function handleTitleCeded(event: TitleCededEvent): void {
 }
 
 export function handleHolderChanged(event: HolderChangedEvent): void {
-  const titleEscrowContract = TitleEscrowCloneable.bind(event.address);
-
   const titleEscrowEntity = fetchTitleEscrow(event.address);
 
-  const tryRegistryAddress = titleEscrowContract.try_tokenRegistry();
+  const tokenEntity = Token.load(titleEscrowEntity.token);
+  if (tokenEntity !== null) {
+    tokenEntity.holder = event.params.newHolder.toHex();
+    tokenEntity.save();
+  }
 
   const entityId = `${event.address.toHex()}-${event.logIndex.toString()}`;
-  const registryAddress = tryRegistryAddress.reverted ? Address.zero().toHex() : tryRegistryAddress.value.toHex();
   const prevHolder = event.params.previousHolder.equals(Address.zero())
     ? ""
     : event.params.previousHolder.toHex();
@@ -75,7 +76,7 @@ export function handleHolderChanged(event: HolderChangedEvent): void {
   const titleEscrowHolderTransferEntity = new TitleEscrowHolderTransfer(entityId);
   titleEscrowHolderTransferEntity.transaction = fetchTransaction(event).id;
   titleEscrowHolderTransferEntity.timestamp = event.block.timestamp;
-  titleEscrowHolderTransferEntity.registry = registryAddress;
+  titleEscrowHolderTransferEntity.registry = titleEscrowEntity.registry;
   titleEscrowHolderTransferEntity.token = titleEscrowEntity.token;
   titleEscrowHolderTransferEntity.titleEscrow = event.address.toHex();
   titleEscrowHolderTransferEntity.beneficiary = titleEscrowEntity.beneficiary;


### PR DESCRIPTION
## Summary
To add token and account entity relationship. This will allow more flexible queries to be made directly from account entity about its related tokens.

## Changes
* Add relationship mapping logic 
* Update schema
* Fix an issue with repeated holder change records due to contract emitting holder change event even when a title escrow is newly created (what a quirky design of the contracts, really😑🤷‍♂️)

## Issues
* https://www.pivotaltracker.com/story/show/181351621

