### PR TITLE
feat: add inferred token transfer type

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -4,6 +4,15 @@ enum TitleEscrowStatus {
   Exited
 }
 
+enum TokenTransferType {
+  Unknown
+  Mint
+  Restoration
+  Acceptance
+  Surrender
+  TitleEscrowTransfer
+}
+
 type TitleEscrow @entity {
   id: ID!
   registry: TokenRegistry!
@@ -135,6 +144,9 @@ type TokenTransfer implements Event @entity {
   fromHolder: Account
   toBeneficiary: Account
   toHolder: Account
+
+  "Inferred token transfer type"
+  type: TokenTransferType!
 }
 
 interface Event {

--- a/src/escrow.ts
+++ b/src/escrow.ts
@@ -1,14 +1,14 @@
-import { Address, BigInt } from "@graphprotocol/graph-ts/index";
+import { Address, BigInt } from "@graphprotocol/graph-ts";
 import {
   HolderChanged as HolderChangedEvent, Surrender as SurrenderEvent, TitleCeded as TitleCededEvent,
   TitleEscrowCloneable, TransferTitleEscrowApproval as TransferTitleEscrowApprovalEvent,
 } from "../generated/templates/TitleEscrowCloneable/TitleEscrowCloneable";
 import { Surrender, TitleEscrowApproval, TitleEscrowHolderTransfer, Token } from "../generated/schema";
 import { fetchAccount, fetchTitleEscrow, fetchToken, fetchTokenRegistry, fetchTransaction } from "./utils/fetchers";
-import { getTokenEntityId } from "./utils/helpers";
+import { getEventId, getTokenEntityId } from "./utils/helpers";
 
 export function handleSurrender(event: SurrenderEvent): void {
-  const eventId = `${event.transaction.hash.toHex()}-${event.logIndex.toString()}`;
+  const eventId = getEventId(event);
 
   const registryEntity = fetchTokenRegistry(event.params.tokenRegistry);
   const tokenEntity = fetchToken(registryEntity, event.params.tokenId);
@@ -27,7 +27,7 @@ export function handleSurrender(event: SurrenderEvent): void {
 }
 
 export function handleTransferTitleEscrowApproval(event: TransferTitleEscrowApprovalEvent): void {
-  const eventId = `${event.transaction.hash.toHex()}-${event.logIndex.toString()}`;
+  const eventId = getEventId(event);
 
   const titleEscrowContract = TitleEscrowCloneable.bind(event.address);
   const tryRegistryAddress = titleEscrowContract.try_tokenRegistry();

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,4 +1,4 @@
-import { BigInt } from "@graphprotocol/graph-ts/index";
+import { BigInt, ethereum } from "@graphprotocol/graph-ts";
 
 export function mapTitleEscrowStatusEnum(enumIdx: BigInt): string {
   if (enumIdx.equals(BigInt.fromI32(0))) {
@@ -15,4 +15,8 @@ export function mapTitleEscrowStatusEnum(enumIdx: BigInt): string {
 
 export function getTokenEntityId(tokenRegistryId: String, tokenId: BigInt): string {
   return `${tokenRegistryId}/${tokenId.toHex()}`;
+}
+
+export function getEventId(event: ethereum.Event): string {
+  return `${event.transaction.hash.toHex()}-${event.logIndex.toString()}`;
 }


### PR DESCRIPTION
## Summary
The objective of this PR is to reduce the cognitive load needed of a developer to decipher the Bill of Lading transfer types manually from the raw events. By looking at the endorsement chain implementation in the TradeTrust website, one will realise the amount of effort to implement and understanding about TradeTrust is required only to interpret the different transfers; the need to implement the logic to differentiate the various permutations of transfer addresses just to figure out a transfer type is tedious, messy, difficult to maintain and error prone!🤯

With the addition of the `type` field in this PR, all the logic to decipher the transfers will be baked in the subgraph for the developer. The developer then only has to retrieve the `type` field of the `TokenTransfer` entity and use the value however he wants, hence, allowing the developer to focus on building his actual product.

This PR will add a `type` field which indicates the type of transfer made on the token to the `TokenTransfer` entity. As this is not a value coming directly from the contract, this field is inferred from several events within the contracts. 

## Changes
* Add transfer type enum in schema
* Add type field to TokenTransfer entity
* Update mapping logic

